### PR TITLE
Update usernames.ejs - Show current Voting Power

### DIFF
--- a/views/usernames.ejs
+++ b/views/usernames.ejs
@@ -24,7 +24,7 @@
                 <div class="alert alert-success" role="alert">
                     <center><h4 class="alert-heading"><%= (sp).toFixed(3) %> SMOKE POWER</h4></center>
                     <div class="progress">
-                        <div class="progress-bar progress-bar-striped bg-success" role="progressbar" style=<%= `width:${datau[0].voting_power/100}%` %> aria-valuenow="0" aria-valuemin="0" aria-valuemax="100"><%= datau[0].voting_power/100+`%` %></div>
+                        <div class="progress-bar progress-bar-striped bg-success" role="progressbar" style=<%= `width:${datau[0].voting_power/100+(Math.round(((new Date().getTime()/1000)-(new Date(datau[0].last_vote_time).getTime()/1000))/43.20)/100)}%` %> aria-valuenow="0" aria-valuemin="0" aria-valuemax="100"><%= datau[0].voting_power/100+(Math.round(((new Date().getTime()/1000)-(new Date(datau[0].last_vote_time).getTime()/1000))/43.20)/100)+`%` %></div>
                     </div>
                     
                     <hr>


### PR DESCRIPTION
Rather than showing the Voting Power stat which represents the voting power after the last vote was placed, show the current Voting Power which reflects the increase since time has passed.
Notes:  Doesn't mod by 100 for accounts that have waited past 100%VP.  Sometimes gives some weird long fraction.